### PR TITLE
fix sklearn dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,22 @@
+# run: conda env create --file environment.yml
+name: detritalpy
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - python>=3.9
+  - pip
+  - numpy
+  - matplotlib
+  - pandas
+  - xlrd
+  - folium
+  - vincent
+  - simplekml
+  - scipy
+  - scikit-learn
+  - openpyxl
+  - pip:
+    - KDEpy
+    - peakutils
+

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
     url="https://github.com/grsharman/detritalpy",
     download_url="https://github.com/grsharman/detritalPy/archive/v1.3.34.tar.gz",
     install_requires=['numpy','matplotlib','pandas','xlrd','folium','vincent','simplekml',
-        'scipy','sklearn','KDEpy','peakutils','openpyxl'],
+        'scipy','scikit-learn','KDEpy','peakutils','openpyxl'],
     classifiers=[
         "Programming Language :: Python :: 3",
         'Intended Audience :: Science/Research',


### PR DESCRIPTION
setup.py contains `sklearn` dependency which is deprecated and `scikit-learn` should be used instead. See https://pypi.org/project/sklearn

I also include the conda environment file to simplify installation for conda/mamba based users.